### PR TITLE
Listcontents implementation adhere to interface

### DIFF
--- a/src/CurlFtpAdapter.php
+++ b/src/CurlFtpAdapter.php
@@ -432,7 +432,7 @@ class CurlFtpAdapter extends AbstractFtpAdapter
         $connection = $this->getConnection();
         $result = $connection->exec([CURLOPT_CUSTOMREQUEST => $request]);
         if ($result === false) {
-            return false;
+            return [];
         }
 
         if ($directory === '/') {

--- a/tests/CurlFtpAdapterTest.php
+++ b/tests/CurlFtpAdapterTest.php
@@ -245,6 +245,16 @@ class CurlFtpAdapterTest extends TestCase
         $this->assertCount(1, $this->adapter->listContents(dirname($path)));
     }
 
+    /**
+     * @dataProvider withSubFolderProvider
+     *
+     * @param $path
+     */
+    public function testListContentsEmptyPath($path)
+    {
+        $this->assertCount(0, $this->adapter->listContents(dirname($path)));
+    }
+
     public function filesProvider()
     {
         return [

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -13,7 +13,7 @@ error_test()
 
 # creating directory for resources
 if test ! -d "tests/resources"; then
-	mkdir -m=0777 "tests/resources"
+	mkdir -m 0777 "tests/resources"
 	if test $? != 0; then exit 1; fi
 fi
 


### PR DESCRIPTION
Without the patch the listContents implementation gives the following error message:

Argument 1 passed to League\Flysystem\Util\ContentListingFormatter::formatListing() must be of the type array, boolean given, called in /var/www/vendor/league/flysystem/src/Filesystem.php on line 272