### PR TITLE
Enable certification checking per default

### DIFF
--- a/src/CurlFtpAdapter.php
+++ b/src/CurlFtpAdapter.php
@@ -58,8 +58,6 @@ class CurlFtpAdapter extends AbstractFtpAdapter
         $this->connection->setOptions([
             CURLOPT_URL => $this->getBaseUri(),
             CURLOPT_USERPWD => $this->getUsername() . ':' . $this->getPassword(),
-            CURLOPT_SSL_VERIFYPEER => false,
-            CURLOPT_SSL_VERIFYHOST => false,
             CURLOPT_FTPSSLAUTH => CURLFTPAUTH_TLS,
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_CONNECTTIMEOUT => $this->getTimeout(),


### PR DESCRIPTION
Enable certification checking should be enabled by default. Please note:

* `CURLOPT_SSL_VERIFYPEER`

  > WARNING: disabling verification of the certificate allows bad guys to man-in-the-middle the communication without you knowing it. Disabling verification makes the communication insecure.

  -- https://curl.haxx.se/libcurl/c/CURLOPT_SSL_VERIFYPEER.html

* `CURLOPT_SSL_VERIFYHOST`

  > When the verify value is 0, the connection succeeds regardless of the names in the certificate. Use that ability with caution!

  -- https://curl.haxx.se/libcurl/c/CURLOPT_SSL_VERIFYHOST.html

  > In production environments the value of this option should be kept at 2 (default value).

  -- http://php.net/manual/en/function.curl-setopt.php

Users of this library should not be exposed to insecure behaviour. Since this library is published on Packagist with some popularity (> 100), I decided to write a pull request.

If necessary, the certificate checks could be disabled by the user by setting the connection options.