### PR TITLE
Add connection timeout support

### DIFF
--- a/src/CurlFtpAdapter.php
+++ b/src/CurlFtpAdapter.php
@@ -102,7 +102,8 @@ class CurlFtpAdapter extends AbstractFtpAdapter
     /**
      * @return bool
      */
-    protected function hasConnectionReachedTimeout() {
+    protected function hasConnectionReachedTimeout()
+    {
         return $this->connectionTimestamp + $this->getTimeout() < time();
     }
 

--- a/src/CurlFtpAdapter.php
+++ b/src/CurlFtpAdapter.php
@@ -27,6 +27,9 @@ class CurlFtpAdapter extends AbstractFtpAdapter
     /** @var Curl */
     protected $connection;
 
+    /** @var int unix timestamp when connection was established */
+    protected $connectionTimestamp = 0;
+
     /** @var bool */
     protected $isPureFtpd;
 
@@ -70,6 +73,7 @@ class CurlFtpAdapter extends AbstractFtpAdapter
         }
 
         $this->pingConnection();
+        $this->connectionTimestamp = time();
         $this->setUtf8Mode();
         $this->setConnectionRoot();
     }
@@ -92,7 +96,14 @@ class CurlFtpAdapter extends AbstractFtpAdapter
      */
     public function isConnected()
     {
-        return $this->connection !== null;
+        return $this->connection !== null && !$this->hasConnectionReachedTimeout();
+    }
+
+    /**
+     * @return bool
+     */
+    protected function hasConnectionReachedTimeout() {
+        return $this->connectionTimestamp + $this->getTimeout() < time();
     }
 
     /**


### PR DESCRIPTION
Add connection timeout support by establishing a new connection when AbstractFtpAdapter->timeout is reached, instead of re-using the existing cached forever connection.

This fixes a major issue that affected us whereby files could not be downloaded from a specific FTPS service.

The problem only presented itself in longer-running worker processes, on specific FTP servers. Presumably where the connection is forcibly hung up by the FTP server after a certain period of time.