### PR TITLE
Add support for enableTimestampsOnUnixListings config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ $adapter = new CurlFtpAdapter([
   'timeout' => 90,		// connect timeout
   'sslVerifyPeer' => 0, // using 0 is insecure, use it only if you know what you're doing
   'sslVerifyHost' => 0, // using 0 is insecure, use it only if you know what you're doing
+  'enableTimestampsOnUnixListings' => true,
   
   /** proxy settings */
   'proxyHost' => 'proxy-server.example.com',

--- a/src/CurlFtpAdapter.php
+++ b/src/CurlFtpAdapter.php
@@ -28,6 +28,7 @@ class CurlFtpAdapter extends AbstractFtpAdapter
         'proxyPort',
         'proxyUsername',
         'proxyPassword',
+        'enableTimestampsOnUnixListings',
     ];
 
     /** @var Curl */


### PR DESCRIPTION
When config set to true, enables timestamps for FTP servers
that return unix-style listings