### PR TITLE
Fixed CurlFtpAdapter::listDirectoryContentsRecursive

### DIFF
--- a/src/CurlFtpAdapter.php
+++ b/src/CurlFtpAdapter.php
@@ -593,9 +593,8 @@ class CurlFtpAdapter extends AbstractFtpAdapter
         $output = [];
 
         foreach ($listing as $item) {
-            if ($item['type'] === 'file') {
-                $output[] = $item;
-            } elseif ($item['type'] === 'dir') {
+            $output[] = $item;
+            if ($item['type'] === 'dir') {
                 $output = array_merge($output, $this->listDirectoryContentsRecursive($item['path']));
             }
         }


### PR DESCRIPTION
Fixed listDirectoryContentsRecursive. The method fails to return dir listings when traversing the remote directory.
When CurlFtpAdapter::listDirectoryContents is called without the `recursive` flag, both files and directories are returned.