### PR TITLE
fix order of parameters on array_key_exists

### DIFF
--- a/src/Curl.php
+++ b/src/Curl.php
@@ -76,7 +76,7 @@ class Curl
      */
     public function hasOption($key): bool
     {
-        return array_key_exists($this->options, $key);
+        return array_key_exists($key, $this->options);
     }
 
     /**


### PR DESCRIPTION
the order of parameters are wrong... so we can't use the hasOption and getOption methods