### PR TITLE
Adds config option to disable LIST command arguments

### DIFF
--- a/src/CurlFtpAdapter.php
+++ b/src/CurlFtpAdapter.php
@@ -826,7 +826,7 @@ class CurlFtpAdapter extends AbstractFtpAdapter
 
         $response = $this->rawCommand($this->connection, 'OPTS UTF8 ON');
         [$code, $message] = explode(' ', end($response), 2);
-        if ($code !== '200') {
+        if (!in_array($code, ['200', '202'])) {
             throw new RuntimeException(
                 'Could not set UTF-8 mode for connection: '.$this->getHost().'::'.$this->getPort()
             );

--- a/src/CurlFtpAdapter.php
+++ b/src/CurlFtpAdapter.php
@@ -899,7 +899,7 @@ class CurlFtpAdapter extends AbstractFtpAdapter
 
         $response = $this->rawCommand($this->connection, 'OPTS UTF8 ON');
         [$code, $message] = explode(' ', end($response), 2);
-        if (!in_array($code, ['200', '202'])) {
+        if (! in_array($code, ['200', '202'])) {
             throw new RuntimeException(
                 'Could not set UTF-8 mode for connection: '.$this->getHost().'::'.$this->getPort()
             );

--- a/src/CurlFtpAdapter.php
+++ b/src/CurlFtpAdapter.php
@@ -333,7 +333,7 @@ class CurlFtpAdapter extends AbstractFtpAdapter
         $connection = $this->getConnection();
 
         $result = $connection->exec([
-            CURLOPT_URL => $this->getBaseUri().'/'.$path,
+            CURLOPT_URL => $this->getBaseUri().$this->getRoot().'/'.$path,
             CURLOPT_UPLOAD => 1,
             CURLOPT_INFILE => $resource,
         ]);
@@ -534,7 +534,7 @@ class CurlFtpAdapter extends AbstractFtpAdapter
         $connection = $this->getConnection();
 
         $result = $connection->exec([
-            CURLOPT_URL => $this->getBaseUri().'/'.$path,
+            CURLOPT_URL => $this->getBaseUri().$this->getRoot().'/'.$path,
             CURLOPT_FILE => $stream,
         ]);
 

--- a/src/CurlFtpAdapter.php
+++ b/src/CurlFtpAdapter.php
@@ -572,6 +572,12 @@ class CurlFtpAdapter extends AbstractFtpAdapter
         }
         $listing = $this->normalizeListing(explode(PHP_EOL, $result), '');
 
+        $pathIsDir = pathinfo($path, PATHINFO_EXTENSION) === '';
+
+        if ($pathIsDir && count($listing) === 0) {
+            return ['type' => 'dir', 'path' => $path];
+        }
+
         return current($listing);
     }
 

--- a/src/CurlFtpAdapter.php
+++ b/src/CurlFtpAdapter.php
@@ -33,7 +33,11 @@ class CurlFtpAdapter extends AbstractFtpAdapter
         'proxyPassword',
         'verbose',
         'enableTimestampsOnUnixListings',
+        'useListCommandArguments',
     ];
+
+    /** @var bool */
+    protected $useListCommandArguments = true;
 
     /** @var Curl */
     protected $connection;
@@ -73,6 +77,14 @@ class CurlFtpAdapter extends AbstractFtpAdapter
 
     /** @var bool */
     protected $verbose = false;
+
+    /**
+     * @param bool $ftps
+     */
+    public function setUseListCommandArguments($use): void
+    {
+        $this->useListCommandArguments = (bool) $use;
+    }
 
     /**
      * @param bool $ftps
@@ -550,7 +562,8 @@ class CurlFtpAdapter extends AbstractFtpAdapter
             return ['type' => 'dir', 'path' => ''];
         }
 
-        $request = rtrim('LIST -A '.$this->normalizePath($path));
+        $arguments = $this->useListCommandArguments ? '-A ' : '';
+        $request = rtrim('LIST '.$arguments.$this->normalizePath($path));
 
         $connection = $this->getConnection();
         $result = $connection->exec([CURLOPT_CUSTOMREQUEST => $request]);
@@ -619,7 +632,8 @@ class CurlFtpAdapter extends AbstractFtpAdapter
             return $this->listDirectoryContentsRecursive($directory);
         }
 
-        $request = rtrim('LIST -aln '.$this->normalizePath($directory));
+        $arguments = $this->useListCommandArguments ? '-aln ' : '';
+        $request = rtrim('LIST '.$arguments.$this->normalizePath($directory));
 
         $connection = $this->getConnection();
         $result = $connection->exec([CURLOPT_CUSTOMREQUEST => $request]);
@@ -641,7 +655,8 @@ class CurlFtpAdapter extends AbstractFtpAdapter
      */
     protected function listDirectoryContentsRecursive($directory)
     {
-        $request = rtrim('LIST -aln '.$this->normalizePath($directory));
+        $arguments = $this->useListCommandArguments ? '-aln ' : '';
+        $request = rtrim('LIST '.$arguments.$this->normalizePath($directory));
 
         $connection = $this->getConnection();
         $result = $connection->exec([CURLOPT_CUSTOMREQUEST => $request]);


### PR DESCRIPTION
This pull requests adds a config option to disable the LIST command arguments. It is useable for newer FTP servers, like FileZilla Server versions > 1.1.0, were the FTP command LIST is no longer supporting arguments like "-A" or "-aln".

The additional commit adds the root folder to the `writeStream` and `readStream` methods, since `CURLOPT_URL` needs an absolute URL and the `CWD` command inside the `setConnectionRoot` method has no effect for the two operations.