### PR TITLE
Improves FileZilla compatibility, Adds config setting, Fixes tests

### DIFF
--- a/src/CurlFtpAdapter.php
+++ b/src/CurlFtpAdapter.php
@@ -34,6 +34,7 @@ class CurlFtpAdapter extends AbstractFtpAdapter
         'verbose',
         'enableTimestampsOnUnixListings',
         'useListCommandArguments',
+        'isPureFtpd',
     ];
 
     /** @var bool */
@@ -46,7 +47,7 @@ class CurlFtpAdapter extends AbstractFtpAdapter
     protected $connectionTimestamp = 0;
 
     /** @var bool */
-    protected $isPureFtpd;
+    protected $isPureFtpd = null;
 
     /** @var bool */
     protected $ftps = true;
@@ -138,6 +139,14 @@ class CurlFtpAdapter extends AbstractFtpAdapter
     public function setUtf8($utf8): void
     {
         $this->utf8 = (bool) $utf8;
+    }
+
+    /**
+     * @param bool $isPureFtpd
+     */
+    public function setIsPureFtpd($isPureFtpd): void
+    {
+        $this->isPureFtpd = (bool) $isPureFtpd;
     }
 
     /**
@@ -285,7 +294,6 @@ class CurlFtpAdapter extends AbstractFtpAdapter
         if ($this->connection !== null) {
             $this->connection = null;
         }
-        $this->isPureFtpd = null;
     }
 
     /**

--- a/src/CurlFtpAdapter.php
+++ b/src/CurlFtpAdapter.php
@@ -354,12 +354,12 @@ class CurlFtpAdapter extends AbstractFtpAdapter
     {
         $connection = $this->getConnection();
 
-        $pathDdir = pathinfo($path, PATHINFO_DIRNAME);
-        $pathHasFolders = $pathDdir !== '.';
+        $pathDir = pathinfo($path, PATHINFO_DIRNAME);
+        $pathHasFolders = $pathDir !== '.';
         $requestPath = $pathHasFolders ? $this->applyPathPrefix($path) : $path;
 
         $result = $connection->exec([
-            CURLOPT_URL => $this->getBaseUri().$this->separator.$requestPath,
+            CURLOPT_URL => $this->getBaseUri().$this->separator.rawurlencode($requestPath),
             CURLOPT_UPLOAD => 1,
             CURLOPT_INFILE => $resource,
         ]);
@@ -568,7 +568,7 @@ class CurlFtpAdapter extends AbstractFtpAdapter
         $requestPath = $pathHasFolders ? $this->applyPathPrefix($path) : $path;
 
         $result = $connection->exec([
-            CURLOPT_URL => $this->getBaseUri().$this->separator.$requestPath,
+            CURLOPT_URL => $this->getBaseUri().$this->separator.rawurlencode($requestPath),
             CURLOPT_FILE => $stream,
         ]);
 

--- a/src/CurlFtpAdapter.php
+++ b/src/CurlFtpAdapter.php
@@ -645,7 +645,8 @@ class CurlFtpAdapter extends AbstractFtpAdapter
             return $result;
         }
 
-        if (stristr($path, $this->getPathPrefix())) {
+        $pathPrefix = $this->getPathPrefix();
+        if (substr($path, 0, strlen($pathPrefix)) === $pathPrefix) {
             $path = $this->removePathPrefix($path);
         }
 

--- a/src/CurlFtpAdapter.php
+++ b/src/CurlFtpAdapter.php
@@ -354,14 +354,22 @@ class CurlFtpAdapter extends AbstractFtpAdapter
     {
         $connection = $this->getConnection();
 
+        $pathDdir = pathinfo($path, PATHINFO_DIRNAME);
+        $pathHasFolders = $pathDdir !== '.';
+        $requestPath = $pathHasFolders ? $this->applyPathPrefix($path) : $path;
+
         $result = $connection->exec([
-            CURLOPT_URL => $this->getBaseUri().$this->getRoot().'/'.$path,
+            CURLOPT_URL => $this->getBaseUri().$this->separator.$requestPath,
             CURLOPT_UPLOAD => 1,
             CURLOPT_INFILE => $resource,
         ]);
 
         if ($result === false) {
             return false;
+        }
+
+        if ($pathHasFolders) {
+            $this->setConnectionRoot();
         }
 
         $type = 'file';
@@ -555,8 +563,12 @@ class CurlFtpAdapter extends AbstractFtpAdapter
 
         $connection = $this->getConnection();
 
+        $pathDir = pathinfo($path, PATHINFO_DIRNAME);
+        $pathHasFolders = $pathDir !== '.';
+        $requestPath = $pathHasFolders ? $this->applyPathPrefix($path) : $path;
+
         $result = $connection->exec([
-            CURLOPT_URL => $this->getBaseUri().$this->getRoot().'/'.$path,
+            CURLOPT_URL => $this->getBaseUri().$this->separator.$requestPath,
             CURLOPT_FILE => $stream,
         ]);
 
@@ -567,6 +579,10 @@ class CurlFtpAdapter extends AbstractFtpAdapter
         }
 
         rewind($stream);
+
+        if($pathHasFolders) {
+            $this->setConnectionRoot();
+        }
 
         return ['type' => 'file', 'path' => $path, 'stream' => $stream];
     }

--- a/src/CurlFtpAdapter.php
+++ b/src/CurlFtpAdapter.php
@@ -580,7 +580,7 @@ class CurlFtpAdapter extends AbstractFtpAdapter
 
         rewind($stream);
 
-        if($pathHasFolders) {
+        if ($pathHasFolders) {
             $this->setConnectionRoot();
         }
 

--- a/tests/CurlFtpAdapterTest.php
+++ b/tests/CurlFtpAdapterTest.php
@@ -8,13 +8,15 @@ use League\Flysystem\Util;
 class CurlFtpAdapterTest extends TestCase
 {
     /**
-     * @dataProvider filesProvider
+     * @dataProvider filesAndSubfolderFilesProvider
      *
      * @param $filename
      */
     public function testWrite($filename): void
     {
         $contents = $this->faker()->text;
+
+        $this->createResourceDirIfPathHasDir($filename);
 
         $result = $this->adapter->write($filename, $contents, new Config);
 
@@ -29,13 +31,15 @@ class CurlFtpAdapterTest extends TestCase
     }
 
     /**
-     * @dataProvider filesProvider
+     * @dataProvider filesAndSubfolderFilesProvider
      *
      * @param $filename
      */
     public function testUpdate($filename): void
     {
         $contents = $this->faker()->text;
+
+        $this->createResourceDirIfPathHasDir($filename);
 
         $this->adapter->write($filename, $contents, new Config);
         $this->assertEquals($contents, $this->getResourceContent($filename));
@@ -55,7 +59,7 @@ class CurlFtpAdapterTest extends TestCase
     }
 
     /**
-     * @dataProvider filesProvider
+     * @dataProvider filesAndSubfolderFilesProvider
      *
      * @param $filename
      */
@@ -66,6 +70,8 @@ class CurlFtpAdapterTest extends TestCase
         $stream = fopen('php://memory', 'rb+');
         fwrite($stream, $contents);
         rewind($stream);
+
+        $this->createResourceDirIfPathHasDir($filename);
 
         $this->adapter->writeStream($filename, $stream, new Config);
         $this->assertEquals($contents, $this->getResourceContent($filename));
@@ -120,12 +126,14 @@ class CurlFtpAdapterTest extends TestCase
     }
 
     /**
-     * @dataProvider filesProvider
+     * @dataProvider filesAndSubfolderFilesProvider
      *
      * @param $filename
      */
     public function testDelete($filename): void
     {
+        $this->createResourceDirIfPathHasDir($filename);
+
         $this->adapter->write($filename, 'foo', new Config);
 
         $result = $this->adapter->delete($filename);
@@ -146,12 +154,14 @@ class CurlFtpAdapterTest extends TestCase
     }
 
     /**
-     * @dataProvider filesProvider
+     * @dataProvider filesAndSubfolderFilesProvider
      *
      * @param $filename
      */
     public function testGetSetVisibility($filename): void
     {
+        $this->createResourceDirIfPathHasDir($filename);
+
         $this->adapter->write($filename, 'foo', new Config);
 
         $result = $this->adapter->setVisibility($filename, 'public');
@@ -170,7 +180,7 @@ class CurlFtpAdapterTest extends TestCase
     }
 
     /**
-     * @dataProvider filesProvider
+     * @dataProvider filesAndSubfolderFilesProvider
      *
      * @param $name
      */
@@ -194,7 +204,7 @@ class CurlFtpAdapterTest extends TestCase
     }
 
     /**
-     * @dataProvider filesProvider
+     * @dataProvider filesAndSubfolderFilesProvider
      *
      * @param $name
      */
@@ -204,19 +214,6 @@ class CurlFtpAdapterTest extends TestCase
         $this->createResourceFile($name, $contents);
 
         $this->assertTrue((bool) $this->adapter->has($name));
-    }
-
-    /**
-     * @dataProvider withSubFolderProvider
-     *
-     * @param $path
-     */
-    public function testHasInSubFolder($path): void
-    {
-        $contents = $this->faker()->text;
-        $this->createResourceFile($path, $contents);
-
-        $this->assertTrue((bool) $this->adapter->has($path));
     }
 
     public function testGetMimeType(): void
@@ -253,6 +250,32 @@ class CurlFtpAdapterTest extends TestCase
     public function testListContentsEmptyPath($path): void
     {
         $this->assertCount(0, $this->adapter->listContents(dirname($path)));
+    }
+
+    public function filesAndSubfolderFilesProvider()
+    {
+        return [
+            ['test.txt'],
+            ['..test.txt'],
+            ['test 1.txt'],
+            ['test  2.txt'],
+            ['тест.txt'],
+            [$this->randomFileName()],
+            [$this->randomFileName()],
+            [$this->randomFileName()],
+            [$this->randomFileName()],
+            [$this->randomFileName()],
+            ['test/test.txt'],
+            ['тёст/тёст.txt'],
+            ['test 1/test.txt'],
+            ['test/test 1.txt'],
+            ['test  1/test  2.txt'],
+            [$this->faker()->word.'/'.$this->randomFileName()],
+            [$this->faker()->word.'/'.$this->randomFileName()],
+            [$this->faker()->word.'/'.$this->randomFileName()],
+            [$this->faker()->word.'/'.$this->randomFileName()],
+            [$this->faker()->word.'/'.$this->randomFileName()],
+        ];
     }
 
     public function filesProvider()

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -61,6 +61,14 @@ abstract class TestCase extends BaseTestCase
         ]));
     }
 
+    protected function createResourceDirIfPathHasDir($path): void
+    {
+        $pathDir = pathinfo($path, PATHINFO_DIRNAME);
+        if ($pathDir !== '.') {
+            $this->createResourceDir($pathDir);
+        }
+    }
+
     protected function createResourceDir($path): void
     {
         if (empty($path)) {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -32,6 +32,7 @@ abstract class TestCase extends BaseTestCase
             'passive' => true, // default use PASV mode
             'skipPasvIp' => false, // ignore the IP address in the PASV response
             'verbose' => false, // set verbose mode on/off
+            'useListCommandArguments' => false,
         ]);
     }
 


### PR DESCRIPTION
Added the isPureFtpd property as a config setting, so that we can prevent an unnecessary HELP FTP call if we know that we do (not) connect to an PureFtpd server.

Fixed the tests by adding rawurlencode to the write and read stream CURLOPT_URL's, because of whitespaces in filenames.

Updated the tests by adding a data provider with files without and files with subfolder.

Added tests for FileZilla server behavior (i guess for FileZilla server version >= 1.0.0), where the server changes it's working directory to the actual root directory (not the root given in the config), when reading or writing files in subfolders. So we include another `setConnectionRoot` after we have written or read a file with a folder in his path. 

Unfortunately there is no docker image for FileZilla server to include it here. We tested it locally with FileZilla server version 1.3.0.